### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/io.github.nokse22.trivia-quiz.metainfo.xml.in
+++ b/data/io.github.nokse22.trivia-quiz.metainfo.xml.in
@@ -14,7 +14,7 @@ It uses Open Trivia database.
   <launchable type="desktop-id">io.github.nokse22.trivia-quiz.desktop</launchable>
 
   <developer id="io.github.nokse22">
-    <name translatable="no">Nokse</name>
+    <name translate="no">Nokse</name>
   </developer>
 
   <url type="homepage">https://github.com/Nokse22/trivia-quiz</url>
@@ -30,7 +30,7 @@ It uses Open Trivia database.
 
   <releases>
     <release version="0.2.0" date="2024-03-11">
-		  <description  translatable="no">
+		  <description  translate="no">
 			  <p>Minor design improvements</p>
 		    <p>Now it won't ask the same question twice anymore</p>
 		    <p>Better screenshots</p>
@@ -39,27 +39,27 @@ It uses Open Trivia database.
 		  </description>
 	  </release>
     <release version="0.1.4" date="2023-09-04">
-		  <description  translatable="no">
+		  <description  translate="no">
 			  <p>Fixed bug</p>
 		  </description>
 	  </release>
     <release version="0.1.3" date="2023-08-22">
-		  <description  translatable="no">
+		  <description  translate="no">
 			  <p>changed app id</p>
 		  </description>
 	  </release>
     <release version="0.1.2" date="2023-08-22">
-		  <description  translatable="no">
+		  <description  translate="no">
 			  <p>Fixed bugs</p>
 		  </description>
 	  </release>
     <release version="0.1.1" date="2023-08-22">
-		  <description  translatable="no">
+		  <description  translate="no">
 			  <p>Rename the app to trivia quiz</p>
 		  </description>
 	  </release>
     <release version="0.1.0" date="2023-08-22">
-		  <description  translatable="no">
+		  <description  translate="no">
 			  <p>First release!</p>
 		  </description>
 	  </release>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html